### PR TITLE
Add FrankenPHP for testing deployments on production (sample)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM composer:lts AS composer
+
+WORKDIR /app
+
+COPY composer.json composer.lock ./
+RUN composer install --no-dev --optimize-autoloader
+
+COPY . .
+
+
+FROM dunglas/frankenphp:1.0-php8.3
+
+WORKDIR /app
+
+COPY --from=composer /app /app
+
+EXPOSE 80
+
+CMD ["frankenphp", "php-server"]

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,10 +1,14 @@
 version: '3'
 
 tasks:
+  build-css:
+    cmds:
+      - npx @tailwindcss/cli -i ".\assets\css\tailwind.css" -o ".\public\css\styles.min.css" --minify
+    silent: true
   compile-css:
     cmds:
       - npx @tailwindcss/cli -i ".\assets\css\tailwind.css" -o ".\public\css\styles.min.css" --minify --watch
-  #    silent: true
+  #      silent: true
   run-dev:
     cmds:
       - composer dev
@@ -13,3 +17,12 @@ tasks:
     cmds:
       - composer lint
     silent: true
+  docker-build:
+    deps:
+      - build-css
+    cmds:
+      - docker buildx build --network=host -t yapping:latest -f Dockerfile .
+    silent: true
+  serve-prod:
+    cmds:
+      - docker run -e CADDY_GLOBAL_OPTIONS="debug" -e SERVER_NAME="127.0.0.1" -p 80:80 -p 443:443 -p 443:443/udp --name yap yapping:latest

--- a/src/Controllers/InitController.php
+++ b/src/Controllers/InitController.php
@@ -175,6 +175,7 @@ class InitController extends Dependency
 
     protected function redirect(string $path): void
     {
+        header_remove('X-Powered-By');
         //redirect to feeds
         // Set the HTTP status code to 302 (temporary redirect)
         http_response_code(302);

--- a/src/Views/Fragment/Exception.twig
+++ b/src/Views/Fragment/Exception.twig
@@ -4,8 +4,8 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="utf-8">
+    <meta http-equiv="refresh" content="3;url=/feeds">
     <link rel="stylesheet" href="/public/css/styles.min.css">
-
 
     <!--  fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -16,7 +16,7 @@
 
 </head>
 <body>
-{% include "Partials/NavHeader.twig" with{greet: greet, menu: 'Feeds'} %}
+{% include "Partials/NavHeader.twig" with{greet: greet, menu: menu ?? 'Feeds'} %}
 <main class="flex flex-col justify-center items-center mx-auto h-screen">
     <div class="flex flex-col justify-center items-center w-[720px]">
         <h2 class="font-merriWeather font-semibold text-2xl">Something went wrong</h2>
@@ -28,5 +28,9 @@
 </body>
 <script>
     {% include 'Partials/logoutActionBtn.js' %}
+
+    setTimeout(function () {
+        window.location.href = "/feeds";
+    }, 3000);
 </script>
 </html>

--- a/src/Views/Partials/NavHeader.twig
+++ b/src/Views/Partials/NavHeader.twig
@@ -3,7 +3,8 @@
         X Microsite / {{ menu|default('Resource') }}
     </h1>
 
-    <span class="text-gray-700 font-light truncate">
+    {% if greet %}
+        <span class="text-gray-700 font-light truncate">
         {{ greet }},
          <button
                  id="logoutBtn"
@@ -13,4 +14,5 @@
         Logout
     </button>
     </span>
+    {% endif %}
 </div>


### PR DESCRIPTION
 For windows you can use WSL2 with os debian (recommended) and run the build image script


- Automatic SSL with FrankenPHP but limited to "localhost"
so if we use the environment at json config set to PRODUCTION it still accessible... bcz on production the cookies settings is little bit different. 
- Add auto redirect to feeds, if user visit an invalid resource route path within 3s